### PR TITLE
Fix chunking issue on return from settings screen

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/TickAdapter.java
+++ b/app/src/main/java/de/smasi/tickmate/TickAdapter.java
@@ -36,7 +36,8 @@ public class TickAdapter extends BaseAdapter {
     private List<Track> tracks;
     private boolean isTodayAtTop = false;  // Reverses the date ordering - most recent dates at the top
     private static final String TAG = "TickAdapter";
-    private static final int DEFAULT_COUNT_PAST = 14; // by default load 2 weeks of past ticks
+    private static final int DEFAULT_COUNT_PAST = 21; // by default load 3 weeks of past ticks
+    // (see comment by InfiniteScrollAdapter.SCROLL_DOWN_THRESHOLD)
     private static final int DEFAULT_COUNT_AHEAD = 0; // by default show zero days ahead
 
 	public TickAdapter(Context context, Calendar activeDay) {

--- a/app/src/main/java/lab/prada/android/ui/infinitescroll/InfiniteScrollAdapter.java
+++ b/app/src/main/java/lab/prada/android/ui/infinitescroll/InfiniteScrollAdapter.java
@@ -28,7 +28,9 @@ public class InfiniteScrollAdapter<T extends BaseAdapter> extends BaseAdapter {
     private AtomicInteger state = new AtomicInteger(NONE_STATE);
     private boolean mCanReadMore = true;
 
-    private final static int SCROLL_DOWN_THRESHOLD = 30;  // When the date order is reversed, this
+
+    // SCROLL_DOWN_THRESHOLD should be less than TickAdapter.DEFAULT_COUNT_PAST, otherwise the first load happens in two (or more) chunks
+    private final static int SCROLL_DOWN_THRESHOLD = 15;  // When the date order is reversed, this
         // value determines how close 'position' must be to the bottom of the current data set before
         // triggering the addition of new items. This number should be large enough to ensure position
         // will actually reach the threshold, even on high res screens (which may have a large number of items).


### PR DESCRIPTION
The two constants must be set relative to each other to ensure
everything is grabbed in one chunk.