### PR TITLE
Don't force german language in BTC donation info URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Find correlations between your tracks:
 
 Contains icons from the [Glyphicons FREE icon set](http://glyphicons.com/) (CC-BY-3.0)
 
-Bitcoin donations are happily accepted at [18tub3juj26zyGwdpmGDLgtLEpfFf2Nvhu](http://blockchain.info/de/address/18tub3juj26zyGwdpmGDLgtLEpfFf2Nvhu).
+Bitcoin donations are happily accepted at [18tub3juj26zyGwdpmGDLgtLEpfFf2Nvhu](https://blockchain.info/address/18tub3juj26zyGwdpmGDLgtLEpfFf2Nvhu).
 
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=&url=https://github.com/lordi/tickmate&title=Tickmate&language=&tags=github&category=software) 
 


### PR DESCRIPTION
Let the website choose appropriate translation depending on user preferences.

Also changed http to https.