### PR TITLE
Disabled write/read external storage for API level 19 and above

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,9 +8,9 @@
         android:minSdkVersion="11"
         android:targetSdkVersion="23" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" >
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" >
     </uses-permission>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" >
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="18" >
     </uses-permission>
 
     <application


### PR DESCRIPTION
This change just reduce required permission to minimum. Without that some people can be confused why this application ask for accessing their private data (photos, etc.).

For better description of provided changes, I just use quote from official documentation:
Starting in API level 19, this permission is not required to read/write files in your application-specific directories returned by getExternalFilesDir(String) and getExternalCacheDir(). 

http://developer.android.com/reference/android/Manifest.permission.html#WRITE_EXTERNAL_STORAGE