### PR TITLE
Correcting weekly mean calculation

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -324,9 +324,9 @@ public class ShowTrackActivity extends Activity {
 		double days_since_last = -1;
 		
 		if (firstTickDate != null && lastTickDate != null) {
-			double weeks = Math.ceil(((double)(today.getTimeInMillis() - firstTickDate.getTimeInMillis())) / milliSecsInADay / 7.0); 
+			double days = Math.ceil(((double)(today.getTimeInMillis() - firstTickDate.getTimeInMillis())) / milliSecsInADay); 
 			days_since_last = ((double)(today.getTimeInMillis() - lastTickDate.getTimeInMillis())) / milliSecsInADay; 
-			weeklymean = tickCount/weeks;
+			weeklymean = (tickCount/days)*7.0;
 		}
 
 		sn1.setData(tickCount, 0, (String) getText(R.string.show_track_total));


### PR DESCRIPTION
Currently the weekly mean is calculated by (number of ticks / number of weeks), but depending on the current weekday and the weekday when the track began, it will add up to 6 value-zero elements to the mean calculations.

This is corrected by instead calculating the mean by (number of ticks / number of days) * 7.0, which is independent of the current and starting weekday.