### PR TITLE
Prevent Crash when trying to add track to empty list

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/Tickmate.java
+++ b/app/src/main/java/de/smasi/tickmate/Tickmate.java
@@ -288,7 +288,7 @@ public class Tickmate extends ListActivity implements
     }
 
     public Group getCurrentGroup() {
-        if (mCurrentGroupId == TickmateConstants.ALL_GROUPS_SPINNER_INDEX) {
+        if (mCurrentGroupId == TickmateConstants.ALL_GROUPS_SPINNER_INDEX || mCurrentGroupId == Group.ALL_GROUP.getId()) {
             return Group.ALL_GROUP;
         } else {
             return DataSource.getInstance().getGroup(mCurrentGroupId);


### PR DESCRIPTION
Currently Tickmate crashes when tapping on the initially empty list to
add the first track ("Tap here to open the track list editor").
This is corrected by the proposed bug fix.