### PR TITLE
Fix issue #89

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/widgets/MultiTickButton.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/MultiTickButton.java
@@ -79,7 +79,9 @@ public class MultiTickButton extends Button implements OnClickListener, OnLongCl
 		Calendar c = Calendar.getInstance();
 		c.set(Calendar.MILLISECOND, 0);
 
-		if (c.get(Calendar.DAY_OF_MONTH) == this.date.get(Calendar.DAY_OF_MONTH)) {
+		if (c.get(Calendar.DAY_OF_YEAR) == this.date.get(Calendar.DAY_OF_YEAR) &&
+				c.get(Calendar.YEAR) == this.date.get(Calendar.YEAR) &&
+				c.get(Calendar.ERA) == this.date.get(Calendar.ERA)) {
 			DataSource.getInstance().setTick(this.getTrack(), c, false);
 		} else {
 			DataSource.getInstance().setTick(this.getTrack(), this.date, false);


### PR DESCRIPTION
Multi-Tick track entries on a same day of month in the past appeared (only after resuming) on the current day. This PR fixes issue #89 .