### PR TITLE
Fix longest break duration

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -252,7 +252,7 @@ public class ShowTrackActivity extends Activity {
                 int days_since = (int)((tick.date.getTimeInMillis() - last_on.getTimeInMillis()) / (24*60*60*1000));
                 //Log.d("Tickmate", String.format("Days_since=%d, from %d to %d", days_since, tick.date.getTimeInMillis(), last_on.getTimeInMillis()));
                 if (days_since > this.streakOffMaximum) {
-                    this.streakOffMaximum = days_since;
+                    this.streakOffMaximum = days_since - 1;
                 }
 
                 if (days_since == 0) {


### PR DESCRIPTION
If you do an activity say on Monday and on Wednesday, then there is a break
of one day where you didn't do that activity (longest break = 1 day). Hence
if you do an activity on two consecutive days, then there is no break at all
(longest break = 0 days). Currently Tickmate shows 2 and 1 days, respectively,
in the above cases. This is going to be fixed by this commit. See also first bullet
of #88.