### PR TITLE
Fix longest streak calculation for single day activities

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -193,7 +193,7 @@ public class ShowTrackActivity extends Activity {
             this.streaksData.add(0);
             this.streaksKeys.add(0, "");
         }
-        this.streakOnMaximum = 0;
+        this.streakOnMaximum = ticks.size() > 0 ? 1 : 0;
         this.streakOffMaximum = 0;
         Calendar last_on = null;
 


### PR DESCRIPTION
If an activity is done on say two, three, four and so on days in a row,
then the longest streak is 2, 3, 4 and so on (correct). If an activity is
done on just one day and then paused, then the longest streak is
currently 0 (same as if no activity at all has ever been done). Based on
the above reasoning it appears more logical to calculate the streak
duration as 1 in this case.