### PR TITLE
Fix time info

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/TickAdapter.java
+++ b/app/src/main/java/de/smasi/tickmate/TickAdapter.java
@@ -62,7 +62,7 @@ public class TickAdapter extends BaseAdapter {
 
     private void updateToday() {
         today = Calendar.getInstance();
-        today.set(Calendar.HOUR, 0);
+        today.set(Calendar.HOUR_OF_DAY, 0);
         today.set(Calendar.MINUTE, 0);
         today.set(Calendar.SECOND, 0);
         today.set(Calendar.MILLISECOND, 0);
@@ -80,7 +80,7 @@ public class TickAdapter extends BaseAdapter {
 			java.text.DateFormat dateFormat = android.text.format.DateFormat
 					.getDateFormat(context);
 			Log.d(TAG, "Active day set to " + dateFormat.format(activeDay.getTime()));
-			activeDay.set(Calendar.HOUR, 0);
+			activeDay.set(Calendar.HOUR_OF_DAY, 0);
 			activeDay.set(Calendar.MINUTE, 0);
 			activeDay.set(Calendar.SECOND, 0);
 			activeDay.set(Calendar.MILLISECOND, 0);

--- a/app/src/main/java/de/smasi/tickmate/widgets/MultiTickButton.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/MultiTickButton.java
@@ -82,7 +82,7 @@ public class MultiTickButton extends Button implements OnClickListener, OnLongCl
 		if (c.get(Calendar.DAY_OF_YEAR) == this.date.get(Calendar.DAY_OF_YEAR) &&
 				c.get(Calendar.YEAR) == this.date.get(Calendar.YEAR) &&
 				c.get(Calendar.ERA) == this.date.get(Calendar.ERA)) {
-			DataSource.getInstance().setTick(this.getTrack(), c, false);
+			DataSource.getInstance().setTick(this.getTrack(), c, true);
 		} else {
 			DataSource.getInstance().setTick(this.getTrack(), this.date, false);
 		}

--- a/app/src/main/java/de/smasi/tickmate/widgets/TickButton.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/TickButton.java
@@ -83,7 +83,15 @@ public class TickButton extends ToggleButton implements OnCheckedChangeListener 
             //  TODO Anything we should do to ensure that all appropriate fields in all objects get updated when the user changes the tick color setting for a track?
             mTickedDrawable = TickColor.getTickedButtonDrawable(this.getContext(), track.getTickColor().getColorValue());
             setBackgroundDrawable(mTickedDrawable);
-            ds.setTick(tb.getTrack(), tb.getDate(), true);
+
+            Calendar c = Calendar.getInstance();
+            if (c.get(Calendar.DAY_OF_YEAR) == tb.getDate().get(Calendar.DAY_OF_YEAR) &&
+                    c.get(Calendar.YEAR) == tb.getDate().get(Calendar.YEAR) &&
+                    c.get(Calendar.ERA) == tb.getDate().get(Calendar.ERA)) {
+                ds.setTick(tb.getTrack(), c, true);
+            } else {
+                ds.setTick(tb.getTrack(), tb.getDate(), false);
+            }
         }
         else {
             setBackgroundDrawable(mUnTickedDrawable);


### PR DESCRIPTION
1. Toggle (single tick) ticks didn't include time info for today. This was fixed to include
   the time info when the tick is ticked.
2. Ticks for other dates than today, which don't have the time info, indicated the
    hour as 12 if the list view row was created after noon. This was fixed to always put 0
    to the hour field no matter when the row was created.