### PR TITLE
Additional option for editable days: today, yesterday/last weekend

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/widgets/ButtonHelpers.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/ButtonHelpers.java
@@ -24,12 +24,18 @@ public class ButtonHelpers {
         today.set(Calendar.SECOND, 0);
         today.set(Calendar.MILLISECOND, 0);
 
+        Calendar yesterday;
+
         switch (limitActivePref) {
             case "ALLOW_CURRENT":
                 return (date.compareTo(today) == 0);
             case "ALLOW_CURRENT_AND_NEXT_DAY":
-                Calendar yesterday = (Calendar) today.clone();
+                yesterday = (Calendar) today.clone();
                 yesterday.add(Calendar.DATE, -1);
+                return (date.compareTo(yesterday) >= 0);
+            case "ALLOW_CURRENT_AND_NEXT_DAY_AND_WEEKEND":
+                yesterday = (Calendar) today.clone();
+                yesterday.add(Calendar.DATE, today.get(Calendar.DAY_OF_WEEK) == Calendar.MONDAY ? -2 : -1);
                 return (date.compareTo(yesterday) >= 0);
             case "ALLOW_ALL":
             default:

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,6 +68,7 @@
     <string-array name="pref_titles_active_date">
         <item>Nur aktiver Tag</item>
         <item>Aktiver Tag und Tag davor</item>
+        <item>Aktiver Tag und Tag/Wochenende davor</item>
         <item>Alle Tage</item>
     </string-array>
     <string name="notify_user_ticking_disabled">Dieser Tick kann nicht editiert werden. Welche Tage editiert werden können, kann in den Einstellungen geändert werden.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string-array name="pref_titles_active_date">
         <item>Active day only</item>
         <item>Active day and day before</item>
+        <item>Active day and day/weekend before</item>
         <item>All days</item>
     </string-array>
     <string name="notify_user_ticking_disabled">Changing this tick is disabled. You can specify which days are editable in the settings.</string>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -4,6 +4,7 @@
     <string-array name="pref_values_active_date">:
         <item>ALLOW_CURRENT</item>
         <item>ALLOW_CURRENT_AND_NEXT_DAY</item>
+        <item>ALLOW_CURRENT_AND_NEXT_DAY_AND_WEEKEND</item>
         <item>ALLOW_ALL</item>
     </string-array>
 


### PR DESCRIPTION
This is a modification of the today + yesterday (active day and day before) option
for the case that you'll update your diary on weekdays only. On Mondays it additionally
allows the preceding Saturday so that you can update activities that happened on the 
last weekend.
Localizations for PL, CZ, and IT yet to be supplied.

This is an option I need for myself as I update the diary on weekdays only. Not
sure if this is useful for anyone else, but adding an additional option doesn't
do any harm I guess.