### PR TITLE
Enter tick count on long click

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/SettingsActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/SettingsActivity.java
@@ -26,6 +26,7 @@ public class SettingsActivity extends PreferenceActivity {
     private void setupSimplePreferencesScreen() {
         addPreferencesFromResource(R.xml.pref_general);
         bindPreferenceSummaryToValue(findPreference("active-date-key"));
+        bindPreferenceSummaryToValue(findPreference("long-click-key"));
     }
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -97,4 +97,12 @@
     <string name="pref_multiple_entries_enabled_summary">Pro Tag werden mehrere Klicks gezählt. Durch langes Drücken wird der Wert wieder vermindert.</string>
     <string name="backup_folder">Der Backup-Ordner ist:</string>
 
+    <!-- New in 1.4.4 -->
+    <string name="pref_title_long_click">Langer Klick auf einen Tick</string>
+    <string-array name="pref_titles_long_click">
+        <item>Eingabe der Tickanzahl</item>
+        <item>Entfernt letzten Tick</item>
+    </string-array>
+    <string name="set_number_of_ticks">Anzahl Ticks %1$s</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,4 +97,12 @@
     <string name="pref_multiple_entries_enabled_summary">Multiple taps on a day will be counted. Use long press to decrease the counter.</string>
     <string name="backup_folder">The backup folder is:</string>
 
+    <!-- New in 1.4.4 -->
+    <string name="pref_title_long_click">Long click on tick</string>
+    <string-array name="pref_titles_long_click">
+        <item>Enter number of ticks</item>
+        <item>Remove last tick</item>
+    </string-array>
+    <string name="set_number_of_ticks">Number of ticks %1$s</string>
+
 </resources>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -7,4 +7,10 @@
         <item>ALLOW_ALL</item>
     </string-array>
 
+    <string-array name="pref_values_long_click">:
+        <item>LONGCLICK_PICK_VALUE</item>
+        <item>LONGCLICK_DECREMENT</item>
+    </string-array>
+
+
 </resources>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -15,4 +15,13 @@
         android:positiveButtonText="@null"
         android:title="@string/pref_title_limit_active_date" />
 
+    <ListPreference
+        android:defaultValue="LONGCLICK_DECREMENT"
+        android:entries="@array/pref_titles_long_click"
+        android:entryValues="@array/pref_values_long_click"
+        android:key="long-click-key"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null"
+        android:title="@string/pref_title_long_click" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Using numberpicker to allow either scrolling and picking a number
or directly entering the number of ticks (0-99). Enter 0 to remove
all ticks.

Setting of how to handle long click on tick: remove last tick
(old behaviour, default) or enter tick count (new option).

This implements feature request #86.