### PR TITLE
accessibility improvemente - labeling elements

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/IconListAdapter.java
+++ b/app/src/main/java/de/smasi/tickmate/views/IconListAdapter.java
@@ -59,6 +59,9 @@ public class IconListAdapter extends BaseAdapter {
 		int icon_id = r.getIdentifier((String)getItem(position), "drawable", context.getPackageName());
 
         imageView.setImageResource(icon_id);
+        imageView.setContentDescription(icon_names.get(position));
+        //imageView.setMinimumWidth(100);
+        //imageView.setMinimumHeight(100);
         return imageView;
     }
 

--- a/app/src/main/java/de/smasi/tickmate/views/IconListAdapter.java
+++ b/app/src/main/java/de/smasi/tickmate/views/IconListAdapter.java
@@ -60,8 +60,6 @@ public class IconListAdapter extends BaseAdapter {
 
         imageView.setImageResource(icon_id);
         imageView.setContentDescription(icon_names.get(position));
-        //imageView.setMinimumWidth(100);
-        //imageView.setMinimumHeight(100);
         return imageView;
     }
 

--- a/app/src/main/java/de/smasi/tickmate/views/TickColorListAdapter.java
+++ b/app/src/main/java/de/smasi/tickmate/views/TickColorListAdapter.java
@@ -44,6 +44,7 @@ public class TickColorListAdapter extends BaseAdapter {
         imageView.setPadding(8, 8, 8, 8);
         int color = TickColor.getColor(position).getColorValue();
         imageView.setImageDrawable(TickColor.getTickedButtonDrawable(mContext, color));
+        imageView.setContentDescription(TickColor.getColor(position).getName());
         return imageView;
     }
 }


### PR DESCRIPTION
Hi. I've been doing research about accessibility properties for mobile applications and evaluated your application. I'm suggesting labeling the icons and colours in chooser dialogs. Moreover, icons and colours in the chooser dialogs should be larger, at least 48dp x 48dp. Currently, they are 42dp x 42dp. I haven't fixed this issue since my goal is just to provide an example. 

You can find ways to improve your app accessibility by looking at [android's accessibility page](https://developer.android.com/guide/topics/ui/accessibility/apps.html)

I have developed an academic accessibility testing tool for Android applications. Let me know if you have any interested in using this tool in this or other applications you may have or collaborate. 

Marcelo Medeiros Eler