### PR TITLE
Feature show pauses

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/database/DataSource.java
+++ b/app/src/main/java/de/smasi/tickmate/database/DataSource.java
@@ -583,6 +583,7 @@ public class DataSource {
 		c.set(Calendar.HOUR_OF_DAY, cursor.getInt(5));
 		c.set(Calendar.MINUTE, cursor.getInt(6));
 		c.set(Calendar.SECOND, cursor.getInt(7));
+		c.set(Calendar.MILLISECOND, 0);
 		Tick tick = new Tick(cursor.getInt(1), c);
 		tick.tick_id = cursor.getInt(0);
 		return tick;

--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -198,6 +198,9 @@ public class ShowTrackActivity extends Activity {
 
 			// Collect all data
 			for (Tick tick : ticks) {
+				tick.date.set(Calendar.HOUR_OF_DAY,0);
+				tick.date.set(Calendar.MINUTE,0);
+				tick.date.set(Calendar.SECOND,0);
 				int day_of_week = tick.date.get(Calendar.DAY_OF_WEEK) - today.getFirstDayOfWeek();
 				if (day_of_week < 0) day_of_week += 7;
 				int newcount = this.weekdaysData.get(day_of_week)+1;
@@ -294,14 +297,23 @@ public class ShowTrackActivity extends Activity {
 		
 		if (ticks.size() > 0) {
 			firstTickDate = ticks.get(0).date;
+			firstTickDate.set(Calendar.HOUR_OF_DAY,0);
+			firstTickDate.set(Calendar.MINUTE,0);
+			firstTickDate.set(Calendar.SECOND,0);
 			lastTickDate = ticks.get(ticks.size() - 1).date;
+			lastTickDate.set(Calendar.HOUR_OF_DAY,0);
+			lastTickDate.set(Calendar.MINUTE,0);
+			lastTickDate.set(Calendar.SECOND,0);
 		}
 		else {
 			firstTickDate = null;
 			lastTickDate = null;
 		}
 		today = Calendar.getInstance();
-	
+		today.set(Calendar.HOUR_OF_DAY,0);
+		today.set(Calendar.MINUTE,0);
+		today.set(Calendar.SECOND,0);
+
 		fillTrackUI();
 		
 	}

--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -190,84 +190,81 @@ public class ShowTrackActivity extends Activity {
         }
         this.streakOnMaximum = ticks.size() > 0 ? 1 : 0;
         this.streakOffMaximum = 0;
-        Calendar last_on = null;
 
-		// Collect all data
-		for (Tick tick : ticks) {
-            int day_of_week = tick.date.get(Calendar.DAY_OF_WEEK) - today.getFirstDayOfWeek();
-            if (day_of_week < 0) day_of_week += 7;
-			int newcount = this.weekdaysData.get(day_of_week)+1;
-			if (newcount > this.weekdaysMaximum) {
-				this.weekdaysMaximum = newcount;
-			}
-			this.weekdaysData.set(day_of_week, newcount);
-			
-			int weekyear = tick.date.get(Calendar.YEAR) + tick.date.get(Calendar.WEEK_OF_YEAR) * 10000;
-			if (weekyear_to_index.containsKey(weekyear)) {
-				int index = weekyear_to_index.get(weekyear);
-				int newcount2 = this.weeksData.get(index)+1;
-				if (newcount2 > this.weeksMaximum)
-					this.weeksMaximum = newcount2;
-				this.weeksData.set(index, newcount2);
-			}
-			
-			int monthyear = tick.date.get(Calendar.YEAR) + tick.date.get(Calendar.MONTH) * 10000;
-			if (monthyear_to_index.containsKey(monthyear)) {
-				int index = monthyear_to_index.get(monthyear);
-				int newcount2 = this.monthsData.get(index)+1;
-				if (newcount2 > this.monthsMaximum)
-					this.monthsMaximum = newcount2;
-				this.monthsData.set(index, newcount2);
-			}
-			
-			int quarteryear = tick.date.get(Calendar.YEAR) * 4 + tick.date.get(Calendar.MONTH) / 3;
-			if (quarteryear_to_index.containsKey(quarteryear)) {
-				int index = quarteryear_to_index.get(quarteryear);
-				int newcount2 = this.quarterData.get(index)+1;
-				if (newcount2 > this.quarterMaximum)
-					this.quarterMaximum = newcount2;
-				this.quarterData.set(index, newcount2);
+		if (ticks.size() > 0) {
+			Calendar last_on = firstTickDate;
+			streaksData.set(streaksData.size() - 1, 1);
+
+			// Collect all data
+			for (Tick tick : ticks) {
+				int day_of_week = tick.date.get(Calendar.DAY_OF_WEEK) - today.getFirstDayOfWeek();
+				if (day_of_week < 0) day_of_week += 7;
+				int newcount = this.weekdaysData.get(day_of_week)+1;
+				if (newcount > this.weekdaysMaximum) {
+					this.weekdaysMaximum = newcount;
+				}
+				this.weekdaysData.set(day_of_week, newcount);
+
+				int weekyear = tick.date.get(Calendar.YEAR) + tick.date.get(Calendar.WEEK_OF_YEAR) * 10000;
+				if (weekyear_to_index.containsKey(weekyear)) {
+					int index = weekyear_to_index.get(weekyear);
+					int newcount2 = this.weeksData.get(index)+1;
+					if (newcount2 > this.weeksMaximum)
+						this.weeksMaximum = newcount2;
+					this.weeksData.set(index, newcount2);
+				}
+
+				int monthyear = tick.date.get(Calendar.YEAR) + tick.date.get(Calendar.MONTH) * 10000;
+				if (monthyear_to_index.containsKey(monthyear)) {
+					int index = monthyear_to_index.get(monthyear);
+					int newcount2 = this.monthsData.get(index)+1;
+					if (newcount2 > this.monthsMaximum)
+						this.monthsMaximum = newcount2;
+					this.monthsData.set(index, newcount2);
+				}
+
+				int quarteryear = tick.date.get(Calendar.YEAR) * 4 + tick.date.get(Calendar.MONTH) / 3;
+				if (quarteryear_to_index.containsKey(quarteryear)) {
+					int index = quarteryear_to_index.get(quarteryear);
+					int newcount2 = this.quarterData.get(index)+1;
+					if (newcount2 > this.quarterMaximum)
+						this.quarterMaximum = newcount2;
+					this.quarterData.set(index, newcount2);
+				}
+
+				int cyear = tick.date.get(Calendar.YEAR);
+				if (year_to_index.containsKey(cyear)) {
+					int index = year_to_index.get(cyear);
+					int newcount2 = this.yearsData.get(index) + 1;
+					if (newcount2 > this.yearsMaximum)
+						this.yearsMaximum = newcount2;
+					this.yearsData.set(index, newcount2);
+				}
+
+				int days_since = (int)((tick.date.getTimeInMillis() - last_on.getTimeInMillis()) / (24*60*60*1000));
+				if (days_since > this.streakOffMaximum) {
+					this.streakOffMaximum = days_since - 1;
+				}
+				if (days_since == 1) {
+					// increase last streak by one day
+					int currentStreak = streaksData.get(streaksData.size() - 1) + 1;
+					streaksData.set(streaksData.size() - 1, currentStreak);
+					if (currentStreak > this.streakOnMaximum) {
+						this.streakOnMaximum = currentStreak;
+					}
+				}
+				else if (days_since > 1){
+					streaksData.add(-days_since + 1);	// add a new pause
+					streaksData.add(1);					// add a new streak
+				}
+				last_on = tick.date;
 			}
 
-			int cyear = tick.date.get(Calendar.YEAR);
-			if (year_to_index.containsKey(cyear)) {
-				int index = year_to_index.get(cyear);
-				int newcount2 = this.yearsData.get(index) + 1;
-				if (newcount2 > this.yearsMaximum)
-					this.yearsMaximum = newcount2;
-				this.yearsData.set(index, newcount2);
+			int days_since = (int)((today.getTimeInMillis() - last_on.getTimeInMillis()) / (24*60*60*1000));
+			if (days_since > 0) {
+				streaksData.add(-days_since);
 			}
-
-            if (last_on == null) {
-                streaksData.add(1);
-            }
-            else {
-                tick.date.set(Calendar.MILLISECOND, 0);
-                last_on.set(Calendar.MILLISECOND, 0);
-                int days_since = (int)((tick.date.getTimeInMillis() - last_on.getTimeInMillis()) / (24*60*60*1000));
-                //Log.d("Tickmate", String.format("Days_since=%d, from %d to %d", days_since, tick.date.getTimeInMillis(), last_on.getTimeInMillis()));
-                if (days_since > this.streakOffMaximum) {
-                    this.streakOffMaximum = days_since - 1;
-                }
-
-                if (days_since == 0) {
-                    // multi-tick, ignore
-                }
-                else if (days_since == 1) {
-                    // increase last streak by one day
-                    int currentStreak = streaksData.get(streaksData.size() - 1) + 1;
-                    streaksData.set(streaksData.size() - 1, currentStreak);
-                    if (currentStreak > this.streakOnMaximum) {
-                        this.streakOnMaximum = currentStreak;
-                    }
-                }
-                else {
-                    // add a new streak
-                    streaksData.add(1);
-                }
-            }
-            last_on = tick.date;
-        }
+		}
 
         if (streaksData.size() > 7) {
             streaksData = streaksData.subList(streaksData.size() - 7, streaksData.size());

--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -77,6 +77,7 @@ public class ShowTrackActivity extends Activity {
     private int streakOnMaximum;
     private int streakOffMaximum;
 
+	private final static int NUMBER_OF_CATEGORIES = 7;
 
     @Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -128,11 +129,11 @@ public class ShowTrackActivity extends Activity {
 		this.weeksData = new LinkedList<Integer>();
 		Calendar week = (Calendar) today.clone();
 		week.clear(Calendar.HOUR);
-		for (int i = 0; i < 7; i++) {
+		for (int i = 0; i < NUMBER_OF_CATEGORIES; i++) {
 			//month.getDisplayName(Calendar.WEEK_OF_YEAR, Calendar.SHORT, Locale.getDefault())
 			this.weeksKeys.add(0, Integer.toString(week.get(Calendar.WEEK_OF_YEAR)));
 			int index = week.get(Calendar.YEAR) + week.get(Calendar.WEEK_OF_YEAR) * 10000;
-			weekyear_to_index.put(index, 6-i);
+			weekyear_to_index.put(index, NUMBER_OF_CATEGORIES-1-i);
 			week.add(Calendar.WEEK_OF_YEAR, -1);
 			this.weeksData.add(0, 0);
 		}
@@ -144,10 +145,10 @@ public class ShowTrackActivity extends Activity {
 		this.monthsData = new LinkedList<Integer>();
 		Calendar month = (Calendar) today.clone();
 		month.clear(Calendar.HOUR);
-		for (int i = 0; i < 7; i++) {
+		for (int i = 0; i < NUMBER_OF_CATEGORIES; i++) {
 			this.monthsKeys.add(0, month.getDisplayName(Calendar.MONTH, Calendar.SHORT, locale));
 			int index = month.get(Calendar.YEAR) + month.get(Calendar.MONTH) * 10000;
-			monthyear_to_index.put(index, 6-i);
+			monthyear_to_index.put(index, NUMBER_OF_CATEGORIES-1-i);
 			month.add(Calendar.MONTH, -1);
 			this.monthsData.add(0, 0);			
 		}
@@ -158,11 +159,11 @@ public class ShowTrackActivity extends Activity {
 		this.quarterData = new LinkedList<Integer>();
 		Calendar quarter = (Calendar) today.clone();
 		quarter.clear(Calendar.HOUR);
-		for (int i = 0; i < 7; i++) {
+		for (int i = 0; i < NUMBER_OF_CATEGORIES; i++) {
 			//month.getDisplayName(Calendar.WEEK_OF_YEAR, Calendar.SHORT, Locale.getDefault())
 			this.quarterKeys.add(0, "Q" + Integer.toString(quarter.get(Calendar.MONTH)/3+1));
 			int index = quarter.get(Calendar.YEAR) * 4 + quarter.get(Calendar.MONTH) / 3;
-			quarteryear_to_index.put(index, 6-i);
+			quarteryear_to_index.put(index, NUMBER_OF_CATEGORIES-1-i);
 			quarter.add(Calendar.MONTH, -3);
 			this.quarterData.add(0, 0);			
 		}
@@ -173,10 +174,10 @@ public class ShowTrackActivity extends Activity {
 		this.yearsData = new LinkedList<Integer>();
 		Calendar year = (Calendar) today.clone();
 		year.clear(Calendar.HOUR);
-		for (int i = 0; i < 7; i++) {
+		for (int i = 0; i < NUMBER_OF_CATEGORIES; i++) {
 			this.yearsKeys.add(0, Integer.toString(year.get(Calendar.YEAR)));
 			int index = year.get(Calendar.YEAR);
-			year_to_index.put(index, 6-i);
+			year_to_index.put(index, NUMBER_OF_CATEGORIES-1-i);
 			year.add(Calendar.YEAR, -1);
 			this.yearsData.add(0, 0);
 		}
@@ -184,7 +185,7 @@ public class ShowTrackActivity extends Activity {
         // Prepare streaks
         this.streaksData = new LinkedList<>();
         this.streaksKeys = new LinkedList<>();
-        for (int i = 0; i < 7; i++) {
+        for (int i = 0; i < 2 * NUMBER_OF_CATEGORIES; i++) {
             this.streaksData.add(0);
             this.streaksKeys.add(0, "");
         }
@@ -263,11 +264,14 @@ public class ShowTrackActivity extends Activity {
 			int days_since = (int)((today.getTimeInMillis() - last_on.getTimeInMillis()) / (24*60*60*1000));
 			if (days_since > 0) {
 				streaksData.add(-days_since);
+				if (days_since > this.streakOffMaximum) {
+					this.streakOffMaximum = days_since;
+				}
 			}
 		}
 
-        if (streaksData.size() > 7) {
-            streaksData = streaksData.subList(streaksData.size() - 7, streaksData.size());
+        if (streaksData.size() > 2 * NUMBER_OF_CATEGORIES) {
+            streaksData = streaksData.subList(streaksData.size() - 2 * NUMBER_OF_CATEGORIES, streaksData.size());
         }
 
         if (this.weeksMaximum < 7)
@@ -341,7 +345,7 @@ public class ShowTrackActivity extends Activity {
         streakOffNumber.setColor(track.getTickColor().getColorValue());
 
         graph_streaks = (SummaryGraph) findViewById(R.id.summaryGraph_streaks);
-        graph_streaks.setData(this.streaksData, this.streaksKeys, this.streakOnMaximum);
+        graph_streaks.setData(this.streaksData, this.streaksKeys, this.streakOnMaximum, this.streakOffMaximum);
         graph_streaks.setColor(track.getTickColor().getColorValue());
 
         graph_weekdays = (SummaryGraph) findViewById(R.id.summaryGraph_weekdays);

--- a/app/src/main/java/de/smasi/tickmate/widgets/SummaryGraph.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/SummaryGraph.java
@@ -86,7 +86,7 @@ public class SummaryGraph extends View {
 
 		int len = this.data.size();
 
-		if (len == 0 || maximum == 0f)
+		if (len == 0)
 			return;
 
 	    paint.setAntiAlias(true);
@@ -104,6 +104,8 @@ public class SummaryGraph extends View {
 		final int fontBottom = fontMetricsInt.bottom;
 
 		float margin = MARKER_RADIUS + fontBottom + fontTop;  // for point/axis labels below/above chart area
+		if (this.maximum <= 0)
+			this.maximum = 1f;
 		float height0 = this.maximum / (this.maximum + this.minimum) * (getHeight() - 2 * margin);
 		                // height of positive section of chart
 		float height = height0 + margin; // distance from top to abscissa

--- a/app/src/main/java/de/smasi/tickmate/widgets/SummaryGraph.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/SummaryGraph.java
@@ -6,6 +6,7 @@ import android.graphics.Paint;
 import android.graphics.Paint.Align;
 import android.graphics.Paint.Style;
 import android.graphics.Path;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
@@ -25,25 +26,25 @@ public class SummaryGraph extends View {
 		init(context);
 	}
 
-
 	public SummaryGraph(Context context, AttributeSet attrs) {
 		super(context, attrs);
 		init(context);
 	}
 
-
 	protected Paint paint;
 	private List<Integer> data;
 	private List<String> keys;
-	private Integer maximum;
+	private float maximum;
+	private float minimum;
 	private boolean cyclic;
-	private float density;
     private int mColor;
+	private int mTextColor;
+	private int mMarkerColor;
+	final static float MARKER_RADIUS = 6f;
 
 	public boolean isCyclic() {
 		return cyclic;
 	}
-
 
 	public void setCyclic(boolean cyclic) {
 		this.cyclic = cyclic;
@@ -61,26 +62,33 @@ public class SummaryGraph extends View {
 		paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 		path = new Path();
 
-		this.data = new LinkedList<Integer>();
-		this.keys = new LinkedList<String>();
-		this.maximum = 7;
+		this.data = new LinkedList<>();
+		this.keys = new LinkedList<>();
 		this.cyclic = false;
-        this.mColor = getResources().getColor(android.R.color.holo_blue_light);
-		
-		this.density = context.getResources().getDisplayMetrics().density;
-
+		this.mColor = ContextCompat.getColor(context, android.R.color.holo_blue_light);
+		this.mTextColor = ContextCompat.getColor(context, android.R.color.secondary_text_dark);
+		this.mMarkerColor = ContextCompat.getColor(context, android.R.color.white);
 	}
 
-
 	public void setData(List<Integer> data, List<String> keys, Integer maximum) {
+		setData( data, keys, maximum, 0 );
+	}
+
+	public void setData(List<Integer> data, List<String> keys, Integer maximum, Integer minimum) {
 		this.data = data;
 		this.keys = keys;
 		this.maximum = maximum;
+		this.minimum = minimum;
 	}
 
 	@Override
 	protected void onDraw(Canvas canvas) {
-		
+
+		int len = this.data.size();
+
+		if (len == 0 || maximum == 0f)
+			return;
+
 	    paint.setAntiAlias(true);
 	    paint.setTextAlign(Align.CENTER);
 	
@@ -91,43 +99,45 @@ public class SummaryGraph extends View {
         int textSize = getResources().getDimensionPixelSize(R.dimen.fontsize_small);
 		paint.setTextSize(textSize);
 
-		float bottomGap = textSize + 4.0f * density;
-		float height = getHeight() - (textSize + 3.0f * density);
-		float height0 = height - bottomGap;
+		Paint.FontMetricsInt fontMetricsInt = paint.getFontMetricsInt();
+		final int fontTop = -fontMetricsInt.top; // distances above baseline are negative
+		final int fontBottom = fontMetricsInt.bottom;
+
+		float margin = MARKER_RADIUS + fontBottom + fontTop;  // for point/axis labels below/above chart area
+		float height0 = this.maximum / (this.maximum + this.minimum) * (getHeight() - 2 * margin);
+		                // height of positive section of chart
+		float height = height0 + margin; // distance from top to abscissa
 		float width = getWidth();
 
-		int len = this.data.size();
-		
-		if (len == 0)
-			return;
-		
-		// this part needs some refactoring
-		path.reset();
-		path.moveTo((float) ((-0.5)*width/len), height);
+		float deltaX = width/len;
+		float x = -0.5f * deltaX;
+		float x0 = -deltaX;
 		float oldH = height;
+		float h;
+		path.reset();
+		path.moveTo(x, height);
 		if (this.cyclic) {
-			float h = (height0-this.data.get(len - 1)/(1.0f*this.maximum)*height0) + bottomGap;
-			path.lineTo((float) ((-0.5)*width/len), h);
+			h = margin + height0 - this.data.get(len - 1) / this.maximum * height0;
+			path.lineTo(x, h);
 			oldH = h;
 		}
 		
 		for (int i=0; i < len; i++) {
-			int val = this.data.get(i);
-			float h = (height0-val/(1.0f*this.maximum)*height0) + bottomGap;
-			float x0 = (i)*width/len;
-			float x = (i+0.5f)*width/len;
+			h = margin + height0 - this.data.get(i) / this.maximum * height0;
+			x0 += deltaX;
+			x += deltaX;
 			path.cubicTo(x0, oldH, x0, h, x, h);
 			oldH = h;
 		}
 
+		x += deltaX;
 		if (this.cyclic) {
-			float h = (height0-this.data.get(0)/(1.0f*this.maximum)*height0) + bottomGap;
-			float x = (float) ((len+0.5f)*width/len);
+			h = margin + height0 - this.data.get(0) / this.maximum * height0;
 			path.cubicTo(width, oldH, width, h, x, h);
-			path.lineTo((float) ((len+0.5f)*width/len), height);
+			path.lineTo(x, height);
 		}
 		else 
-			path.cubicTo((float) ((len+0.5f)*width/len), oldH, width, height, width, height);
+			path.cubicTo(x, oldH, width, height, width, height);
 
         int dpSize = 2;
         DisplayMetrics dm = getResources().getDisplayMetrics() ;
@@ -142,31 +152,31 @@ public class SummaryGraph extends View {
         paint.setStyle(Style.STROKE);
         canvas.drawPath(path, paint);
 
-        // vertical lines
-        //canvas.drawLine(0, 0, width, height, paint);
-        //canvas.drawLine(0, height, width, 0, paint);
-        //canvas.drawRect(0, 0, width, height, paint);
         canvas.drawLine(0, height, width, height, paint);
 
         paint.setStyle(Style.FILL);
 
+		x = -0.5f * deltaX;
 		for (int i=0; i < len; i++) {
 			int val = this.data.get(i);
-			float h = (height0-val/(1.0f*this.maximum)*height0) + bottomGap;
-			float x = (i+0.5f)*width/len;
+			h =  margin + height0 - val / this.maximum * height0;
+			x += deltaX;
 			paint.setStrokeWidth(1);
 			paint.setColor(mColor);
-			//canvas.drawRect(i*width/len, h, (i+1)*width/len, height, paint);
-			if (val > 0) {
-				paint.setColor(getResources().getColor(android.R.color.secondary_text_dark));
-				canvas.drawText(Integer.toString(val), x, h-9.5f,paint);
-				paint.setColor(getResources().getColor(android.R.color.white));
-				canvas.drawCircle((i+0.5f)*width/len, h, 6.0f, paint);
+			if (val != 0) {
+				paint.setColor(mTextColor);
+				if (val > 0 ) {
+					canvas.drawText(Integer.toString(val), x, h - MARKER_RADIUS - fontBottom, paint);
+				} else {
+					canvas.drawText(Integer.toString(-val), x, h + MARKER_RADIUS + fontTop, paint);
+				}
+				paint.setColor(mMarkerColor);
+				canvas.drawCircle(x, h, MARKER_RADIUS, paint);
 				paint.setColor(mColor);
-				canvas.drawCircle((i+0.5f)*width/len, h, 3.0f, paint);
+				canvas.drawCircle(x, h, MARKER_RADIUS / 2, paint);
 			}
-			paint.setColor(getResources().getColor(android.R.color.secondary_text_dark));
-			canvas.drawText(keys.get(i), (i+0.5f)*width/len, height+(textSize+ 1.0f * density),paint);			
+			paint.setColor(mTextColor);
+			canvas.drawText(keys.get(i), x, height + MARKER_RADIUS + fontTop, paint);
 		}
 	}
 }

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -91,7 +91,7 @@
     <string name="pref_title_color">Barva</string>
 
     <!-- New in 1.4.2 -->
-    <string name="title_section_streaks">Řada</string>
+    <string name="title_section_streaks">Řada/Pauzy</string>
     <string name="longest_streak_on">Nejdelší řada</string>
     <string name="longest_streak_off">Nejdelší pauza</string>
     <string name="pref_multiple_entries_enabled_summary">Několikanásobná ťuknutí za den budou počítána. Dlouhým stlačením snížit počítadlo.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,7 +92,7 @@
     <string name="pref_title_color">Farbe</string>
 
     <!-- New in 1.4.2 -->
-    <string name="title_section_streaks">Ketten</string>
+    <string name="title_section_streaks">Ketten/Pausen</string>
     <string name="longest_streak_on">Längste Kette</string>
     <string name="longest_streak_off">Längste Pause</string>
     <string name="pref_multiple_entries_enabled_summary">Pro Tag werden mehrere Klicks gezählt. Durch langes Drücken wird der Wert wieder vermindert.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -91,7 +91,7 @@
     <string name="pref_title_color">Kolor</string>
 
     <!-- New in 1.4.2 -->
-    <string name="title_section_streaks">Serie</string>
+    <string name="title_section_streaks">Serie/Przerwy</string>
     <string name="longest_streak_on">Najdłuższa seria</string>
     <string name="longest_streak_off">Najdłuższa przerwa</string>
     <string name="pref_multiple_entries_enabled_summary">Zliczanych będzie wiele wystąpień w ciągu dnia. Przytrzymaj, aby zmniejszyć licznik.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="pref_title_color">Color</string>
 
     <!-- New in 1.4.2 -->
-    <string name="title_section_streaks">Streaks</string>
+    <string name="title_section_streaks">Streaks/Pauses</string>
     <string name="longest_streak_on">Longest streak</string>
     <string name="longest_streak_off">Longest break</string>
     <string name="pref_multiple_entries_enabled_summary">Multiple taps on a day will be counted. Use long press to decrease the counter.</string>


### PR DESCRIPTION
The streaks chart is converted to a streaks/pauses chart with streak peaks showing upward and pause peaks showing downward (inserted as negative numbers in streakData). This neatly corresponds to the longest streak / longest pause indicators to the right of the chart, see new screenshot #105 .

Code cleanup of SummaryGraph and moderate refactor of onDraw. Generic distances between curve/axis/markers and labels based on fontMetrics instead of hard coded values. This prevents the number labels from directly sitting on the point markers and gives a more uniform appearance of point and category labels.