### PR TITLE
Trend indicator

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/views/SettingsActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/SettingsActivity.java
@@ -27,6 +27,7 @@ public class SettingsActivity extends PreferenceActivity {
         addPreferencesFromResource(R.xml.pref_general);
         bindPreferenceSummaryToValue(findPreference("active-date-key"));
         bindPreferenceSummaryToValue(findPreference("long-click-key"));
+        bindPreferenceSummaryToValue(findPreference("trend-range-key"));
     }
 
 

--- a/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
+++ b/app/src/main/java/de/smasi/tickmate/views/ShowTrackActivity.java
@@ -15,6 +15,8 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import java.lang.Math;
+
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -83,8 +85,8 @@ public class ShowTrackActivity extends Activity {
 	int[] trendRangeValues;						// from pref_values_trend_range
 	String[] trendRangeTitles;
 	int trendRangeIndex;
-	double[] trendSlopes = {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0 }; // length = length of pref_values_trend_range
-	int[] trendAvailable = {0, 0, 0, 0, 0, 0}; 	// same length as trendSlopes[], 0 = trend not available, -1 = trend available
+	double[] trendAngles = {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0 }; // length = length of pref_values_trend_range
+	int[] trendAvailable = {0, 0, 0, 0, 0, 0}; 	// same length as trendAngles[], 0 = trend not available, -1 = trend available
 
 	private final static int NUMBER_OF_CATEGORIES = 7;
 
@@ -386,7 +388,7 @@ public class ShowTrackActivity extends Activity {
 			int n;								 // number of day in range
 			long sx, sxx, sy = 0L, sxy = 0L;
 			int i = 0;							 // cumulative index into trendData
-			for (int j = 0; j < trendSlopes.length; j++){
+			for (int j = 0; j < trendAngles.length; j++){
 				n = trendRangeValues[j] - 1;
 				if ((int) ((today.getTimeInMillis() - firstTickDate.getTimeInMillis()) / (24 * 60 * 60 * 1000)) >= n) {
 					sx = n * (n + 1) / 2;        // some shortcuts for sequential x values, although
@@ -395,17 +397,17 @@ public class ShowTrackActivity extends Activity {
 						sy += trendData[i];
 						sxy += i * trendData[i];
 					}
-					trendSlopes[j] = (double) (sx * sy - (n + 1) * sxy) / ((n + 1) * sxx - sx * sx);
-					// scale to biggest possible slope for single tick track, see github.com/lordi/tickmate/issues/98#issuecomment-300133172
-					double scaleFactor = (n + 1) % 2 == 0 ? 3. / (2. * (n + 1)- 2. / (n + 1)) : 3. / (2. * (n + 1));
-					trendSlopes[j] *= 90. / scaleFactor;
+					trendAngles[j] = Math.toDegrees(Math.atan((double) (sx * sy - (n + 1) * sxy) / ((n + 1) * sxx - sx * sx)));
+					// scale to biggest possible angle for single tick track, see github.com/lordi/tickmate/issues/98#issuecomment-300133172
+					double maxAngle = Math.toDegrees(Math.atan((n + 1) % 2 == 0 ? 3. / (2. * (n + 1)- 2. / (n + 1)) : 3. / (2. * (n + 1))));
+					trendAngles[j] *= 90. / maxAngle;
 					trendAvailable[j] = -1;  	 // trend is available
 				} else {
 					break;						 // no longer trends available
 				}
 			}
 		}
-		sn3.setData(trendSlopes[trendRangeIndex], trendAvailable[trendRangeIndex], trendRangeTitles[trendRangeIndex]);
+		sn3.setData(trendAngles[trendRangeIndex], trendAvailable[trendRangeIndex], trendRangeTitles[trendRangeIndex]);
 		sn3.setColor(track.getTickColor().getColorValue());
 		sn3.setOnClickListener(new View.OnClickListener() {
 			@Override
@@ -414,7 +416,7 @@ public class ShowTrackActivity extends Activity {
 				if (trendRangeIndex >= trendRangeTitles.length){
 					trendRangeIndex = 0;
 				}
-				sn3.setData(trendSlopes[trendRangeIndex], trendAvailable[trendRangeIndex], trendRangeTitles[trendRangeIndex]);
+				sn3.setData(trendAngles[trendRangeIndex], trendAvailable[trendRangeIndex], trendRangeTitles[trendRangeIndex]);
 				sn3.invalidate();
 			}
 		});

--- a/app/src/main/java/de/smasi/tickmate/widgets/SummaryNumber.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/SummaryNumber.java
@@ -102,7 +102,7 @@ public class SummaryNumber extends View {
 			paint.getTextBounds("1", 0, 1, textBounds); // vertically align any value, with and without decimal separator
 			canvas.drawText(text, cx, cy + textBounds.height() / 2f, paint);
 		} else {
-			if (this.number > -90f && this.number < 90f) {
+			if (this.number > -90 && this.number < 90) {
 				text = "\u279E";  // Heavy Triangle-headed Rightwards Arrow
 			} else {
 				this.number = this.number > 0 ? 90.0 : -90.0;  // cap angle at 90° ...

--- a/app/src/main/java/de/smasi/tickmate/widgets/SummaryNumber.java
+++ b/app/src/main/java/de/smasi/tickmate/widgets/SummaryNumber.java
@@ -5,6 +5,8 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
 import android.graphics.Path;
+import android.graphics.Rect;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout.LayoutParams;
@@ -14,16 +16,18 @@ import de.smasi.tickmate.R;
 public class SummaryNumber extends View {
 	Path path;
     private int mColor;
+	private int mNumberColor;
+	private int mTextColor;
 
     public SummaryNumber(Context context, AttributeSet attrs, int defStyle) {
 		super(context, attrs, defStyle);
-		init();
+		init(context);
 	}
 
 
 	public SummaryNumber(Context context, AttributeSet attrs) {
 		super(context, attrs);
-		init();
+		init(context);
 	}
 
 
@@ -35,20 +39,29 @@ public class SummaryNumber extends View {
 
 	public SummaryNumber(Context context) {
 		super(context);
-		init();
+		init(context);
 	}
 
-	private void init() {
+	private void init(Context context) {
 		setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));		
 		paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 		this.number = 23;
 		this.decimals = 1;
 		this.bottomtext = "";
-        this.mColor = getResources().getColor(android.R.color.holo_blue_light);
-
+        this.mColor = ContextCompat.getColor(context, android.R.color.holo_blue_light);
+		this.mNumberColor = ContextCompat.getColor(context, android.R.color.white);
+		this.mTextColor = ContextCompat.getColor(context, android.R.color.secondary_text_dark);
     }
 
-	public void setData(double d, int decimals, String bottomtext) {
+	/**
+	 * Set Data
+	 *
+	 * @param d if decimals >= 0: number to be displayed, else: slope of arrow in degrees (+90° = upright),
+	 *             will be capped to -90° ... +90°
+	 * @param decimals if >= 0: number of decimals for d, else: flag that d should be treated as angle
+	 * @param bottomtext caption to be shown below circle
+	 */
+    public void setData(double d, int decimals, String bottomtext) {
 		this.number = d;
 		this.decimals = decimals;
 		this.bottomtext = bottomtext;
@@ -60,43 +73,47 @@ public class SummaryNumber extends View {
 	    paint.setAntiAlias(true);
 	    paint.setTextAlign(Align.CENTER);
 	
-		// normal
-		paint.setStrokeWidth(0);
-		
 		int bottomtextsize = getResources().getDimensionPixelSize(R.dimen.fontsize_small);
-		
-		float height = getHeight() - 24.0f;
-		float height0 = height - 26.0f;
-		float width = getWidth();
+		paint.setTextSize(bottomtextsize);
+		Paint.FontMetricsInt captionFontMetricsInt = paint.getFontMetricsInt();
+		final int captionFontTop = -captionFontMetricsInt.top; // distances above baseline are negative
+		final int captionFontBottom = captionFontMetricsInt.bottom;
 
-		// vertical lines
-		//canvas.drawLine(0, 0, width, height, paint);
-		//canvas.drawLine(0, height, width, 0, paint);
+		float cx = getWidth() / 2f;
+		float cy = (getHeight() - (captionFontBottom + captionFontTop)) / 2f;
+
+		paint.setColor(mTextColor);
+		canvas.drawText(this.bottomtext, cx, 2 * cy + captionFontTop, paint);
+
 		paint.setStrokeWidth(2);
 		paint.setColor(mColor);
 		paint.setAlpha(128);
 		paint.setStyle(Paint.Style.FILL);  
 
-		float padding = 3.0f;
-		float cx = (float)(width/2.0);
-		float cy = (float)((height - bottomtextsize - padding)/2.0);
 		canvas.drawCircle(cx, cy, cy, paint);
 		paint.setAlpha(32);
 
-		paint.setTextSize((float)(cy));
-
-		paint.setColor(getResources().getColor(android.R.color.white));
-		if (number < 0) {			
-			canvas.drawText("?", cx, (float)(cy+cy/3.0), paint);
+		paint.setColor(mNumberColor);
+		paint.setTextSize(cy);
+		Rect textBounds = new Rect();
+		String text;
+		if (this.decimals >= 0){
+			text = number < 0 ? "?" : String.format(String.format("%%.%df", decimals), number);
+			paint.getTextBounds("1", 0, 1, textBounds); // vertically align any value, with and without decimal separator
+			canvas.drawText(text, cx, cy + textBounds.height() / 2f, paint);
+		} else {
+			if (this.number > -90f && this.number < 90f) {
+				text = "\u279E";  // Heavy Triangle-headed Rightwards Arrow
+			} else {
+				this.number = this.number > 0 ? 90.0 : -90.0;  // cap angle at 90° ...
+				text = "\u279F";  // ... and use Dashed Triangle-headed Rightwards Arrow to visualize the capping
+			}
+			canvas.save();
+			canvas.rotate((float)-this.number, cx, cy);
+			paint.getTextBounds(text, 0, text.length(), textBounds);
+			canvas.drawText(text, cx, cy - (textBounds.bottom + textBounds.top)/ 2f, paint);
+			canvas.restore();
 		}
-		else {
-			canvas.drawText(String.format(String.format("%%.%df", decimals), number), cx, (float)(cy+cy/3.0), paint);
-		}
-		
-		paint.setTextSize(bottomtextsize);
-		paint.setColor(getResources().getColor(android.R.color.secondary_text_dark));
-		
-		canvas.drawText(this.bottomtext, cx, (float)height, paint);
 	}
 
 

--- a/app/src/main/res/layout/activity_show_track.xml
+++ b/app/src/main/res/layout/activity_show_track.xml
@@ -128,12 +128,14 @@
                             android:id="@+id/summaryNumberStreakOn"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
+                            android:layout_marginBottom="2.5dp"
                             android:layout_weight="1.0"/>
 
                         <de.smasi.tickmate.widgets.SummaryNumber
                             android:id="@+id/summaryNumberStreakOff"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
+                            android:layout_marginTop="2.5dp"
                             android:layout_weight="1.0"/>
 
                     </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,5 +105,14 @@
         <item>Entfernt letzten Tick</item>
     </string-array>
     <string name="set_number_of_ticks">Anzahl Ticks %1$s</string>
+    <string name="pref_title_trend_range">Trendbereich</string>
+    <string-array name="pref_titles_trend_range">
+        <item>Wochentrend</item>
+        <item>14-Tage-Trend</item>
+        <item>Monatstrend</item>
+        <item>Quartalstrend</item>
+        <item>Halbjahrestrend</item>
+        <item>Jahrestrend</item>
+    </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,5 +105,14 @@
         <item>Remove last tick</item>
     </string-array>
     <string name="set_number_of_ticks">Number of ticks %1$s</string>
+    <string name="pref_title_trend_range">Trend range</string>
+    <string-array name="pref_titles_trend_range">
+        <item>1-week trend</item>
+        <item>2-week trend</item>
+        <item>1-month trend</item>
+        <item>3-month trend</item>
+        <item>6-month trend</item>
+        <item>1-year trend</item>
+    </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -13,5 +13,13 @@
         <item>LONGCLICK_DECREMENT</item>
     </string-array>
 
+    <string-array name="pref_values_trend_range">
+        <item>7</item>
+        <item>14</item>
+        <item>30</item>
+        <item>91</item>
+        <item>183</item>
+        <item>365</item>
+    </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -13,6 +13,8 @@
         <item>LONGCLICK_DECREMENT</item>
     </string-array>
 
+    <!-- MUST be in ascending order for trend slopes calculation in ShotTrackActivity to work correctly -->
+    <!-- if number of entries is being changed, initialization of trendSlopes[] in ShotTrackActivity must be changed accordingly-->
     <string-array name="pref_values_trend_range">
         <item>7</item>
         <item>14</item>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -24,4 +24,13 @@
         android:positiveButtonText="@null"
         android:title="@string/pref_title_long_click" />
 
+    <ListPreference
+        android:defaultValue="14"
+        android:entries="@array/pref_titles_trend_range"
+        android:entryValues="@array/pref_values_trend_range"
+        android:key="trend-range-key"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null"
+        android:title="@string/pref_title_trend_range" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Implements #98.
Replace the now redundant "Days since last" summary number (days since last can
now be read off the new streaks/breaks chart) by a trend indicator. The trend
is computed as the slope of a linear least square fit calculated over the ticks
of the track within the specified trend range. The trend range can be selected
in the settings (default 2 weeks). No trend indicator will be available if the
trend range reaches back further than the first tick was recorded for that track.
In this case, a '?' will be displayed. Otherwise a tilted arrow shows the trend,
wheras a 45° maximum increasing/decreasing trend will be displayed as a vertical
arrow pointing straight upwards/downwards. Larger trend values are symbolized by
a dashed upwards/downwards arrow to visualized the capping at 45°.
The current day is included in the trend calculation, no matter if it's early or
late on this day.

Refactoring of SummaryNumber to replace hard-coded distances by generic ones
based on font properties. Adjust 'show track' layout to make all summary number
widgets exactly the same size.