### PR TITLE
Bad Typo

### DIFF
--- a/app/src/main/res/xml-de/tracks.xml
+++ b/app/src/main/res/xml-de/tracks.xml
@@ -102,7 +102,7 @@
 
 	<section name="Allgemein">
 		<track icon="@drawable/glyphicons_152_check_white" name="Todo"
-			description="Sachen von der Todo-Liste abgehackt" />
+			description="Sachen von der Todo-Liste abgehakt" />
 
 		<track icon="@drawable/glyphicons_343_thumbs_up_white" name="Guter Tag"
 			description="Insgesamt einen schönen Tag gehabt" />


### PR DESCRIPTION
"Abgehackt" actually means "cut something off" while "abgehakt" (note the missing c) means "check off". "Abhaken" refers to "Haken" which means "check mark" (in this context). It is a common issue in Germany that people get this wrong in their orthography.