### PR TITLE
Issue 142 export error activity not found

### DIFF
--- a/app/src/main/java/de/smasi/tickmate/Tickmate.java
+++ b/app/src/main/java/de/smasi/tickmate/Tickmate.java
@@ -210,7 +210,16 @@ public class Tickmate extends ListActivity implements
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("application/x-sqlite3");
         intent.putExtra(Intent.EXTRA_TITLE, defaultFileName);
-        startActivityForResult(intent, REQUEST_BACKUP_WRITE_URI);
+
+        // issue #142:
+        //      Deactivating File Manager on some phones may make ACTION_CREATE_DOCUMENT unavailable.
+        //      Check if activity is available and fail gracefully otherwise.
+        boolean isActivityAvailable = intent.resolveActivity(getPackageManager()) != null;
+        if (isActivityAvailable) {
+            startActivityForResult(intent, REQUEST_BACKUP_WRITE_URI);
+        } else {
+            Toast.makeText(this,R.string.export_error_activity_not_found,Toast.LENGTH_LONG).show();
+        }
     }
 
     public void importDB() {
@@ -219,7 +228,17 @@ public class Tickmate extends ListActivity implements
         String[] mimetypes = {"application/x-sqlite3", "application/octet-stream"};
         intent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
         intent.setType("*/*");
-        startActivityForResult(intent, REQUEST_BACKUP_READ_URI);
+
+        // issue #142:
+        //      Deactivating File Manager on some phones may make ACTION_OPEN_DOCUMENT unavailable.
+        //      Check if activity is available and fail gracefully otherwise.
+        boolean isActivityAvailable = intent.resolveActivity(getPackageManager()) != null;
+        if (isActivityAvailable) {
+            startActivityForResult(intent, REQUEST_BACKUP_READ_URI);
+        } else {
+            Toast.makeText(this,R.string.import_error_activity_not_found,Toast.LENGTH_LONG).show();
+        }
+
     }
 
     public void jumpToToday() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,4 +127,7 @@
     <string name="reminder_notification_time">Time of day</string>
     <string name="remind_me_at">Remind me at</string>
 
+    <string name="export_error_activity_not_found">ACTION_CREATE_DOCUMENT not available: Please enable File Manager for export.</string>
+    <string name="import_error_activity_not_found">ACTION_CREATE_DOCUMENT not available: Please enable File Manager for import.</string>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 allprojects {


### PR DESCRIPTION
Added availability check for activities ACTION_CREATE_DOCUMENT and ACTION_OPEN_DOCUMENT to fail gracefully with a toast message if not available (Closes #142).

This PR Also bumps gradle to version 4.1.3.