### PR TITLE
Fix Import and Export

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,4 +117,12 @@
 
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.CREATE_DOCUMENT" />
+            <category android:name="android.intent.category.OPENABLE" />
+            <data android:mimeType="application/x-sqlite3"/>
+        </intent>
+    </queries>
+
 </manifest>


### PR DESCRIPTION
Fixes the import and export

adds a query for the create_document intent in the manifest to allow checking the availability of this activity (necessary since sdk 30), since it will return null otherwise and the import/export will fail
see https://www.reddit.com/r/androiddev/comments/v8efd0/update_on_getpackagemanagerresolveactivity_in_new/